### PR TITLE
Patch handling of old unicode/str builtins

### DIFF
--- a/libgsync/drive/__init__.py
+++ b/libgsync/drive/__init__.py
@@ -34,6 +34,10 @@ if debug.enabled():  # pragma: no cover
     import logging
     logging.getLogger().setLevel(logging.DEBUG)
 
+try:
+    unicode("")
+except NameError:
+    unicode = str
 
 oauth2client.util.positional_parameters_enforcement = \
     oauth2client.util.POSITIONAL_IGNORE

--- a/libgsync/output.py
+++ b/libgsync/output.py
@@ -22,7 +22,7 @@ except NameError:
 
 # Make stdout unbuffered.
 WRITER = codecs.getwriter(sys.stdout.encoding)
-sys.stdout = WRITER(os.fdopen(sys.stdout.fileno(), "w", 0), "replace")
+sys.stdout = WRITER(os.fdopen(sys.stdout.fileno(), "wb", 0), "replace")
 
 
 class Channel(object):

--- a/libgsync/output.py
+++ b/libgsync/output.py
@@ -15,6 +15,11 @@ from datetime import datetime
 import traceback
 from libgsync import __version__
 
+try:
+    unicode("")
+except NameError:
+    unicode = str
+
 # Make stdout unbuffered.
 WRITER = codecs.getwriter(sys.stdout.encoding)
 sys.stdout = WRITER(os.fdopen(sys.stdout.fileno(), "w", 0), "replace")

--- a/libgsync/sync/file/__init__.py
+++ b/libgsync/sync/file/__init__.py
@@ -31,6 +31,11 @@ from libgsync.drive.mimetypes import MimeTypes
 from libgsync.options import GsyncOptions
 from libgsync.sync.file.factory import SyncFileFactory
 
+try:
+    unicode("")
+except NameError:
+    unicode = str
+
 
 class EUnknownSourceType(Exception):  # pragma: no cover
     """UnknownSourceType exception"""


### PR DESCRIPTION
This pull request defines a fake `unicode` variable for Python 3 in order to avoid the `NameError` exceptions and ensures that `sys.stdout` is opened in write-bytes mode.