### PR TITLE
Improve transition to Python 3 str/bytes

### DIFF
--- a/libgsync/drive/__init__.py
+++ b/libgsync/drive/__init__.py
@@ -258,7 +258,7 @@ class DrivePathCache(object):
         self.__data = {}
 
         if data is not None:
-            for key, val in data.iteritems():
+            for key, val in six.iteritems(data):
                 path = Drive().normpath(key)
                 if path is None or not isinstance(val, dict):
                     continue
@@ -833,7 +833,7 @@ class Drive(object):
 
         debug(" * merging properties...")
         body = {}
-        for key, val in properties.iteritems():
+        for key, val in six.iteritems(properties):
             if val is not None:
                 body[key] = Drive.utf8(val)
 
@@ -873,7 +873,7 @@ class Drive(object):
         debug("Updating: %s" % repr(path))
 
         # Merge properties
-        for key, val in properties.iteritems():
+        for key, val in six.iteritems(properties):
             # Do not update the ID, always use the path obtained ID.
             if key == 'id':
                 continue

--- a/libgsync/drive/__init__.py
+++ b/libgsync/drive/__init__.py
@@ -883,6 +883,13 @@ class Drive(object):
             debug(" * with: %s = %s" % (repr(key), repr(val)))
             setattr(info, key, Drive.utf8(val))
 
+        # In Python 3, convert any bytes object to str before sending the
+        # request through the Google Drive API.
+        if six.PY3:
+            for key in info.keys():
+                if isinstance(info[key], bytes):
+                    info[key] = info[key].decode("utf-8")
+
         with self.service() as service:
             res = None
             req = service.files().update(

--- a/libgsync/drive/__init__.py
+++ b/libgsync/drive/__init__.py
@@ -386,6 +386,8 @@ class Drive(object):
         if res.status in [200, 202]:
             # API expires every minute.
             apistr = content
+            if six.PY3:
+                apistr = apistr.decode("utf-8")
 
         if not apistr:
             raise NoServiceError

--- a/libgsync/sync/__init__.py
+++ b/libgsync/sync/__init__.py
@@ -34,7 +34,7 @@ class SyncRules(object):
         self.src_file = src_file
         self.dst_file = dst_file
         self.sync_type = sync_type
-        self.changes = bytearray("           ")
+        self.changes = bytearray(b"           ")
         self.action = NOCHANGE
 
         if GsyncOptions.force_dest_file:
@@ -104,10 +104,10 @@ class SyncRules(object):
         """Skip files that match in size"""
 
         if self.src_file.fileSize != self.dst_file.fileSize:
-            self.changes[3] = 's'
+            self.changes[3] = ord('s')
             return False
 
-        self.changes[3] = '.'
+        self.changes[3] = ord('.')
         return True
 
     @debug.function
@@ -118,10 +118,10 @@ class SyncRules(object):
             return False
 
         if self.src_file.md5Checksum != self.dst_file.md5Checksum:
-            self.changes[2] = 'c'
+            self.changes[2] = ord('c')
             return False
 
-        self.changes[2] = '.'
+        self.changes[2] = ord('.')
         return True
 
     @debug.function
@@ -165,11 +165,11 @@ class SyncRules(object):
             return True
 
         if self.dst_file is None:
-            self.changes = bytearray("cf+++++++++")
+            self.changes = bytearray(b"cf+++++++++")
             self.action |= CREATE
 
             if self.is_dir:
-                self.changes[1] = 'd'
+                self.changes[1] = ord('d')
 
             return True
 
@@ -183,28 +183,28 @@ class SyncRules(object):
             self.action |= UPDATE_ATTRS
 
             if GsyncOptions.times:
-                self.changes[4] = 't'
+                self.changes[4] = ord('t')
             else:
-                self.changes[4] = 'T'
+                self.changes[4] = ord('T')
 
         src_st, dst_st = self.src_file.statInfo, self.dst_file.statInfo
 
         if src_st and dst_st:
             if GsyncOptions.perms and dst_st.st_mode != src_st.st_mode:
                 self.action |= UPDATE_ATTRS
-                self.changes[5] = 'p'
+                self.changes[5] = ord('p')
 
             if GsyncOptions.owner and dst_st.st_uid != src_st.st_uid:
                 self.action |= UPDATE_ATTRS
-                self.changes[6] = 'o'
+                self.changes[6] = ord('o')
 
             if GsyncOptions.group and dst_st.st_gid != src_st.st_gid:
                 self.action |= UPDATE_ATTRS
-                self.changes[7] = 'g'
+                self.changes[7] = ord('g')
 
             # Rsync also provides support for these:
-            #     Check acl = self.changes[9] = 'a'
-            #     Check extended attributes = self.changes[10] = 'x'
+            #     Check acl = self.changes[9] = ord('a')
+            #     Check extended attributes = self.changes[10] = ord('x')
 
     def _apply_skip_update(self):
         """Apply skips that are only applicable to data updates"""
@@ -231,7 +231,7 @@ class SyncRules(object):
         self.action = NOCHANGE
 
         if not self._apply_skip_create():
-            self.changes = bytearray("...........")
+            self.changes = bytearray(b"...........")
 
             self._apply_update_attrs()
 
@@ -239,7 +239,7 @@ class SyncRules(object):
                 self.action |= UPDATE_DATA
 
         if self.action & (CREATE | UPDATE_DATA):
-            self.changes[0] = self.sync_type
+            self.changes[0] = ord(self.sync_type)
 
         return self.action, self.changes
 

--- a/libgsync/sync/file/__init__.py
+++ b/libgsync/sync/file/__init__.py
@@ -9,6 +9,7 @@ types.  Obvious types are local (system) and remote (Google drive) files.
 
 import os
 import re
+import six
 import time
 from zlib import compress, decompress
 from base64 import b64encode, b64decode
@@ -240,9 +241,9 @@ class SyncFileInfo(object):
             return
 
         if isinstance(value, unicode):
-            value = unicode(value).encode("utf8")
+            value = unicode(value).encode()
 
-        if isinstance(value, str):
+        if isinstance(value, bytes):
             # First decode using new base64 compressed method.
             try:
                 self._dict['statInfo'] = \
@@ -254,7 +255,7 @@ class SyncFileInfo(object):
 
             # That failed, try to decode using old hex encoding.
             try:
-                dvalue = str(value).decode("hex")
+                dvalue = bytes(value).decode("hex")
                 self._dict['statInfo'] = pickle.loads(dvalue)
                 self._dict['description'] = value
                 return

--- a/libgsync/sync/file/__init__.py
+++ b/libgsync/sync/file/__init__.py
@@ -246,8 +246,12 @@ class SyncFileInfo(object):
         if isinstance(value, bytes):
             # First decode using new base64 compressed method.
             try:
+                content = decompress(b64decode(value))
+                if six.PY3:
+                    content = content.replace(b"_make_", b"")
+                    value = value.decode("utf-8")
                 self._dict['statInfo'] = \
-                    pickle.loads(decompress(b64decode(value)))
+                    pickle.loads(content)
                 self._dict['description'] = value
                 return
             except Exception as ex:

--- a/libgsync/sync/file/__init__.py
+++ b/libgsync/sync/file/__init__.py
@@ -9,10 +9,10 @@ types.  Obvious types are local (system) and remote (Google drive) files.
 
 import os
 import re
-import six
 import time
 from zlib import compress, decompress
 from base64 import b64encode, b64decode
+import six
 import dateutil.parser
 from dateutil.tz import tzutc
 


### PR DESCRIPTION
This pull request includes some changes that smooth the transition to the string handling in Python 3. In particular:
*  The explicit use of the Python 2 `str` builtin is replaced with `bytes`, which is already available in Python 2.6+ as synonym for `str`.
*  The package `libgsync.sync` is converted to use `bytes` objects instead of ambiguous `str` objects.
*  The body requests items in Python 3 are converted to `str` before being sent.