### PR TITLE
Include missing compatibility code for bytes/str

### DIFF
--- a/libgsync/drive/__init__.py
+++ b/libgsync/drive/__init__.py
@@ -316,7 +316,7 @@ class Drive(object):
         strval_unicode = None
 
         if not isinstance(strval, six.string_types):
-            strval = unicode(str(strval))
+            strval = unicode(bytes(strval))
 
         if isinstance(strval, unicode):
             strval_unicode = strval

--- a/libgsync/sync/file/__init__.py
+++ b/libgsync/sync/file/__init__.py
@@ -225,15 +225,19 @@ class SyncFileInfo(object):
         if isinstance(value, (tuple, list)):
             value = os_platform.stat_result(tuple(value))
             self._dict['statInfo'] = value
-            self._dict['description'] = \
-                b64encode(compress(pickle.dumps(value)))
+            description = b64encode(compress(pickle.dumps(value)))
+            if six.PY3:
+                description = description.decode("utf-8")
+            self._dict['description'] = description
 
             return
 
         if isinstance(value, os_platform.stat_result):
             try:
-                self._dict['description'] = \
-                    b64encode(compress(pickle.dumps(value)))
+                description = b64encode(compress(pickle.dumps(value)))
+                if six.PY3:
+                    description = description.decode("utf-8")
+                self._dict['description'] = description
                 self._dict['statInfo'] = value
             except pickle.PicklingError:
                 pass


### PR DESCRIPTION
This pull request converts one old `str` builtin into the compatible `bytes` builtin and includes missing bytes-processing lines for Python 3 in the `SyncFileInfo.set_stat_info` method. This pull request fixes #9 partially.