### PR TITLE
Force pickle protocol to 2

### DIFF
--- a/libgsync/sync/file/__init__.py
+++ b/libgsync/sync/file/__init__.py
@@ -225,7 +225,7 @@ class SyncFileInfo(object):
         if isinstance(value, (tuple, list)):
             value = os_platform.stat_result(tuple(value))
             self._dict['statInfo'] = value
-            description = b64encode(compress(pickle.dumps(value)))
+            description = b64encode(compress(pickle.dumps(value, protocol=2)))
             if six.PY3:
                 description = description.decode("utf-8")
             self._dict['description'] = description
@@ -234,7 +234,7 @@ class SyncFileInfo(object):
 
         if isinstance(value, os_platform.stat_result):
             try:
-                description = b64encode(compress(pickle.dumps(value)))
+                description = b64encode(compress(pickle.dumps(value, protocol=2)))
                 if six.PY3:
                     description = description.decode("utf-8")
                 self._dict['description'] = description


### PR DESCRIPTION
This pull request forces the library to use the `pickle` protocol 2. Otherwise, `gsync` with Python 3
uses pickle protocol 3 or higher, and `gsync` with Python 2 cannot unpickle it later.